### PR TITLE
Fix progress class typo

### DIFF
--- a/src/components/PlaceSelection/PlaceSelection.module.scss
+++ b/src/components/PlaceSelection/PlaceSelection.module.scss
@@ -34,7 +34,7 @@
   }
 }
 
-.porgress {
+.progress {
   padding-left: 3px;
   font-weight: 800;
   text-align: center;

--- a/src/components/PlaceSelection/PlaceSelection.tsx
+++ b/src/components/PlaceSelection/PlaceSelection.tsx
@@ -72,7 +72,7 @@ export default function PlaceSelection({ children }: PlaceSelectionProps) {
           <CarouselNext className={styles.selectionArrow} />
         </Carousel>
         {current !== 0 && count !== 0 && (
-          <p className={styles.porgress}>
+          <p className={styles.progress}>
             {current} / {count}
           </p>
         )}


### PR DESCRIPTION
## Summary
- fix typo in `.porgress` classname in PlaceSelection styles
- update React component to use `.progress`
- align progress indicator indentation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846c0580eac832ca5f68b8ec34a5f1d